### PR TITLE
[Display PR] ORAS Extension

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/auth/silly"
 	_ "github.com/distribution/distribution/v3/registry/auth/token"
 	_ "github.com/distribution/distribution/v3/registry/extension/repository/distribution"
+	_ "github.com/distribution/distribution/v3/registry/extension/repository/oras"
 	_ "github.com/distribution/distribution/v3/registry/proxy"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/filesystem"
@@ -19,6 +20,7 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/oss"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/s3-aws"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/swift"
+	_ "github.com/distribution/distribution/v3/registry/storage/extension/repository/oras"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/ncw/swift v1.0.47
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
+	github.com/oras-project/artifacts-spec v0.0.0-20211011233138-f1308e4c747c
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/oras-project/artifacts-spec v0.0.0-20211011233138-f1308e4c747c h1:LFv8imEWlO82p5yt5oHa8xS8kdE+s8ix4zy3cCSAWDE=
+github.com/oras-project/artifacts-spec v0.0.0-20211011233138-f1308e4c747c/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/registry/extension/repository/oras/extension.go
+++ b/registry/extension/repository/oras/extension.go
@@ -1,0 +1,23 @@
+package oras
+
+import (
+	"context"
+
+	extension "github.com/distribution/distribution/v3/registry/extension"
+	repositoryextension "github.com/distribution/distribution/v3/registry/extension/repository"
+)
+
+func newOrasExtension(ctx context.Context, options map[string]interface{}) ([]extension.Route, error) {
+	return []extension.Route{
+		{
+			Namespace:  "oras",
+			Extension:  "artifacts",
+			Component:  "referrers",
+			Dispatcher: referrersDispatcher,
+		},
+	}, nil
+}
+
+func init() {
+	repositoryextension.Register("oras", newOrasExtension)
+}

--- a/registry/extension/repository/oras/oras.go
+++ b/registry/extension/repository/oras/oras.go
@@ -1,0 +1,135 @@
+package oras
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	extension "github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage/extension/repository/oras"
+	"github.com/gorilla/handlers"
+	"github.com/opencontainers/go-digest"
+	orasartifacts "github.com/oras-project/artifacts-spec/specs-go/v1"
+)
+
+// referrersDispatcher takes the request context and builds the
+// appropriate handler for handling manifest referrer requests.
+func referrersDispatcher(ctx *extension.Context, r *http.Request) http.Handler {
+	handler := &referrersHandler{
+		Context: ctx,
+	}
+
+	q := r.URL.Query()
+	if dgstStr := q.Get("digest"); dgstStr == "" {
+		dcontext.GetLogger(ctx).Errorf("digest not available")
+	} else if d, err := digest.Parse(dgstStr); err != nil {
+		dcontext.GetLogger(ctx).Errorf("error parsing digest=%q: %v", dgstStr, err)
+	} else {
+		handler.Digest = d
+	}
+
+	mhandler := handlers.MethodHandler{
+		"GET": http.HandlerFunc(handler.Get),
+	}
+
+	return mhandler
+}
+
+// referrersResponse describes the response body of the referrers API.
+type referrersResponse struct {
+	Referrers []orasartifacts.Descriptor `json:"references"`
+}
+
+// referrersHandler handles http operations on manifest referrers.
+type referrersHandler struct {
+	*extension.Context
+
+	// Digest is the target manifest's digest.
+	Digest digest.Digest
+}
+
+// Get gets the list of artifacts that reference the given manifest filtered by the artifact type
+// specified in the request.
+func (h *referrersHandler) Get(w http.ResponseWriter, r *http.Request) {
+	dcontext.GetLogger(h).Debug("Get")
+
+	// This can be empty
+	artifactType := r.FormValue("artifactType")
+
+	if h.Digest == "" {
+		h.Errors = append(h.Errors, v2.ErrorCodeManifestUnknown.WithDetail("digest not specified"))
+		return
+	}
+
+	ep, ok := toExtensionProvider(h.Repository)
+	if !ok {
+		h.Errors = append(h.Errors, errcode.ErrorCodeUnsupported.WithDetail("backend does not support extension"))
+		return
+	}
+	es := ep.Extensions(h)
+
+	asi, err := es.Get(h, "oras/artifacts")
+	if err != nil {
+		h.Errors = append(h.Errors, errcode.ErrorCodeUnsupported.WithDetail(err))
+		return
+	}
+	as, ok := asi.(oras.ArtifactService)
+	if !ok {
+		h.Errors = append(h.Errors, errcode.ErrorCodeUnknown.WithDetail("invalid ORAS artifact service"))
+		return
+	}
+
+	referrers, err := as.Referrers(h.Context, h.Digest, artifactType)
+	if err != nil {
+		if _, ok := err.(distribution.ErrManifestUnknownRevision); ok {
+			h.Errors = append(h.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
+		} else {
+			h.Errors = append(h.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		}
+		return
+	}
+
+	if referrers == nil {
+		referrers = []orasartifacts.Descriptor{}
+	}
+
+	response := referrersResponse{
+		Referrers: referrers,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	if err = enc.Encode(response); err != nil {
+		h.Errors = append(h.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}
+
+func decomposeStruct(in interface{}) (out interface{}, ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			out = nil
+			ok = false
+		}
+	}()
+	out = reflect.ValueOf(in).Elem().Field(0).Interface()
+	ok = true
+	return
+}
+
+func toExtensionProvider(i interface{}) (distribution.ExtensionProvider, bool) {
+	tags, ok := i.(distribution.ExtensionProvider)
+	if ok {
+		return tags, true
+	}
+	i, ok = decomposeStruct(i)
+	if !ok {
+		return nil, false
+	}
+	tags, ok = i.(distribution.ExtensionProvider)
+	return tags, ok
+}

--- a/registry/storage/extension/repository/oras/artifact/manifest.go
+++ b/registry/storage/extension/repository/oras/artifact/manifest.go
@@ -1,0 +1,101 @@
+package artifact
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/oras-project/artifacts-spec/specs-go/v1"
+)
+
+func init() {
+	unmarshalFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		d := new(DeserializedManifest)
+		err := d.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+
+		dgst := digest.FromBytes(b)
+		return d, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: v1.MediaTypeArtifactManifest}, err
+	}
+	err := distribution.RegisterManifestSchema(v1.MediaTypeArtifactManifest, unmarshalFunc)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register ORAS artifact manifest: %s", err))
+	}
+}
+
+// Manifest describes ORAS artifact manifests.
+type Manifest struct {
+	inner v1.Manifest
+}
+
+// ArtifactType returns the artifactType of this ORAS artifact.
+func (a Manifest) ArtifactType() string {
+	return a.inner.ArtifactType
+}
+
+// References returns the distribution descriptors for the referenced blobs.
+func (a Manifest) References() []distribution.Descriptor {
+	blobs := make([]distribution.Descriptor, len(a.inner.Blobs))
+	for i := range a.inner.Blobs {
+		blobs[i] = distribution.Descriptor{
+			MediaType: a.inner.Blobs[i].MediaType,
+			Digest:    a.inner.Blobs[i].Digest,
+			Size:      a.inner.Blobs[i].Size,
+		}
+	}
+	return blobs
+}
+
+// Subject returns the the subject manifest this artifact references.
+func (a Manifest) Subject() distribution.Descriptor {
+	return distribution.Descriptor{
+		MediaType: a.inner.Subject.MediaType,
+		Digest:    a.inner.Subject.Digest,
+		Size:      a.inner.Subject.Size,
+	}
+}
+
+// DeserializedManifest wraps Manifest with a copy of the original JSON data.
+type DeserializedManifest struct {
+	Manifest
+
+	// raw is the raw byte representation of the ORAS artifact.
+	raw []byte
+}
+
+// UnmarshalJSON populates a new Manifest struct from JSON data.
+func (d *DeserializedManifest) UnmarshalJSON(b []byte) error {
+	d.raw = make([]byte, len(b))
+	copy(d.raw, b)
+
+	var man v1.Manifest
+	if err := json.Unmarshal(d.raw, &man); err != nil {
+		return err
+	}
+	if man.ArtifactType == "" {
+		return errors.New("artifactType cannot be empty")
+	}
+	d.inner = man
+
+	return nil
+}
+
+// MarshalJSON returns the raw content.
+func (d *DeserializedManifest) MarshalJSON() ([]byte, error) {
+	if len(d.raw) > 0 {
+		return d.raw, nil
+	}
+
+	return nil, errors.New("JSON representation not initialized in DeserializedManifest")
+}
+
+// Payload returns the raw content of the Artifact. The contents can be
+// used to calculate the content identifier.
+func (d DeserializedManifest) Payload() (string, []byte, error) {
+	// NOTE: This is a hack. The media type should be read from storage.
+	return v1.MediaTypeArtifactManifest, d.raw, nil
+}

--- a/registry/storage/extension/repository/oras/extension.go
+++ b/registry/storage/extension/repository/oras/extension.go
@@ -1,0 +1,83 @@
+package oras
+
+import (
+	"context"
+	"path"
+
+	"github.com/distribution/distribution/v3"
+	repositoryextension "github.com/distribution/distribution/v3/registry/storage/extension/repository"
+	"github.com/opencontainers/go-digest"
+)
+
+type orasExtension struct{}
+
+func newOrasExtension(ctx context.Context, options map[string]interface{}) (repositoryextension.RepositoryExtension, error) {
+	return &orasExtension{}, nil
+}
+
+func (oe *orasExtension) Name() string {
+	return "oras/artifacts"
+}
+
+func (oe *orasExtension) Components() []string {
+	return []string{"referrers"}
+}
+
+func (oe *orasExtension) ManifestHandler(ctx context.Context, repo distribution.Repository, store repositoryextension.RepositoryStore) (repositoryextension.ManifestHandler, error) {
+	blobStore, err := manifestStore(ctx, repo, store)
+	if err != nil {
+		return nil, err
+	}
+
+	return &artifactManifestHandler{
+		repository:     repo,
+		blobStore:      blobStore,
+		referrersStore: referrersStoreFactory(repo, store),
+	}, nil
+
+}
+
+func (oe *orasExtension) RepositoryExtension(ctx context.Context, repo distribution.Repository, store repositoryextension.RepositoryStore) (interface{}, error) {
+	blobStore, err := manifestStore(ctx, repo, store)
+	if err != nil {
+		return nil, err
+	}
+
+	return &artifactService{
+		repository:     repo,
+		blobStore:      blobStore,
+		referrersStore: referrersStoreFactory(repo, store),
+	}, nil
+}
+
+func manifestStore(ctx context.Context, repo distribution.Repository, store repositoryextension.RepositoryStore) (distribution.BlobStore, error) {
+	return store.LinkedBlobStore(ctx, repositoryextension.LinkedBlobStoreOptions{
+		RootPath: manifestLinkPath(repo.Named().Name()),
+		ResolvePath: func(name string, dgst digest.Digest) (string, error) {
+			return path.Join(manifestLinkPath(name), dgst.Algorithm().String(), dgst.Hex(), "link"), nil
+		},
+		UseMiddleware: true,
+	})
+}
+
+func referrersStoreFactory(repo distribution.Repository, store repositoryextension.RepositoryStore) referrersStoreFunc {
+	return func(ctx context.Context, revision digest.Digest, artifactType string) (repositoryextension.LinkedBlobStore, error) {
+		rootPathFn := func(name string) string {
+			return path.Join(manifestLinkPath(name), revision.Algorithm().String(), revision.Hex(), "ref")
+		}
+		return store.LinkedBlobStore(ctx, repositoryextension.LinkedBlobStoreOptions{
+			RootPath: rootPathFn(repo.Named().Name()),
+			ResolvePath: func(name string, dgst digest.Digest) (string, error) {
+				return path.Join(rootPathFn(name), dgst.Algorithm().String(), dgst.Hex(), "link"), nil
+			},
+		})
+	}
+}
+
+func manifestLinkPath(name string) string {
+	return path.Join("/docker/registry/", "v2", "repositories", name, "_manifests", "revisions")
+}
+
+func init() {
+	repositoryextension.Register("oras", newOrasExtension)
+}

--- a/registry/storage/extension/repository/oras/manifest.go
+++ b/registry/storage/extension/repository/oras/manifest.go
@@ -1,0 +1,143 @@
+package oras
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	repositoryextension "github.com/distribution/distribution/v3/registry/storage/extension/repository"
+	"github.com/distribution/distribution/v3/registry/storage/extension/repository/oras/artifact"
+	"github.com/opencontainers/go-digest"
+)
+
+// referrersStoreFunc describes a function that returns the referrers store
+// for the given manifest of the given artifactType.
+// A referrers store provides links to referrer manifests.
+type referrersStoreFunc func(ctx context.Context, revision digest.Digest, artifactType string) (repositoryextension.LinkedBlobStore, error)
+
+// artifactManifestHandler is a ManifestHandler that covers ORAS Artifacts.
+type artifactManifestHandler struct {
+	repository     distribution.Repository
+	blobStore      distribution.BlobStore
+	referrersStore referrersStoreFunc
+}
+
+func (amh *artifactManifestHandler) CanUnmarshal(content []byte) bool {
+	var v json.RawMessage
+	return json.Unmarshal(content, &v) == nil
+}
+
+func (amh *artifactManifestHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
+	dcontext.GetLogger(ctx).Debug("(*artifactManifestHandler).Unmarshal")
+
+	dm := &artifact.DeserializedManifest{}
+	if err := dm.UnmarshalJSON(content); err != nil {
+		return nil, err
+	}
+
+	return dm, nil
+}
+
+func (ah *artifactManifestHandler) CanPut(man distribution.Manifest) bool {
+	_, ok := man.(*artifact.DeserializedManifest)
+	return ok
+}
+
+func (ah *artifactManifestHandler) Put(ctx context.Context, man distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {
+	dcontext.GetLogger(ctx).Debug("(*artifactManifestHandler).Put")
+
+	da, ok := man.(*artifact.DeserializedManifest)
+	if !ok {
+		return "", fmt.Errorf("wrong type put to artifactManifestHandler: %T", man)
+	}
+
+	if err := ah.verifyManifest(ctx, *da, skipDependencyVerification); err != nil {
+		return "", err
+	}
+
+	mt, payload, err := da.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	revision, err := ah.blobStore.Put(ctx, mt, payload)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error putting payload into blobstore: %v", err)
+		return "", err
+	}
+
+	err = ah.indexReferrers(ctx, *da, revision.Digest)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error indexing referrers: %v", err)
+		return "", err
+	}
+
+	return revision.Digest, nil
+}
+
+// verifyManifest ensures that the manifest content is valid from the
+// perspective of the registry. As a policy, the registry only tries to
+// store valid content, leaving trust policies of that content up to
+// consumers.
+func (amh *artifactManifestHandler) verifyManifest(ctx context.Context, dm artifact.DeserializedManifest, skipDependencyVerification bool) error {
+	var errs distribution.ErrManifestVerification
+
+	if dm.ArtifactType() == "" {
+		errs = append(errs, distribution.ErrManifestVerification{errors.New("artifactType invalid")})
+	}
+
+	if !skipDependencyVerification {
+		bs := amh.repository.Blobs(ctx)
+
+		// All references must exist.
+		for _, blobDesc := range dm.References() {
+			desc, err := bs.Stat(ctx, blobDesc.Digest)
+			if err != nil && err != distribution.ErrBlobUnknown {
+				errs = append(errs, err)
+			}
+			if err != nil || desc.Digest == "" {
+				// On error here, we always append unknown blob errors.
+				errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: blobDesc.Digest})
+			}
+		}
+
+		ms, err := amh.repository.Manifests(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Validate subject manifest.
+		subject := dm.Subject()
+		exists, err := ms.Exists(ctx, subject.Digest)
+		if !exists || err == distribution.ErrBlobUnknown {
+			errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: subject.Digest})
+		} else if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) != 0 {
+		return errs
+	}
+
+	return nil
+}
+
+// indexReferrers indexes the subject of the given revision in its referrers index store.
+func (amh *artifactManifestHandler) indexReferrers(ctx context.Context, dm artifact.DeserializedManifest, revision digest.Digest) error {
+	artifactType := dm.ArtifactType()
+	subject := dm.Subject()
+
+	store, err := amh.referrersStore(ctx, subject.Digest, artifactType)
+	if err != nil {
+		return err
+	}
+	if err := store.LinkBlob(ctx, distribution.Descriptor{Digest: revision}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/registry/storage/extension/repository/oras/oras.go
+++ b/registry/storage/extension/repository/oras/oras.go
@@ -1,0 +1,73 @@
+package oras
+
+import (
+	"context"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/distribution/distribution/v3/registry/storage/extension/repository/oras/artifact"
+	"github.com/opencontainers/go-digest"
+	artifactv1 "github.com/oras-project/artifacts-spec/specs-go/v1"
+)
+
+type ArtifactService interface {
+	Referrers(ctx context.Context, revision digest.Digest, referrerType string) ([]artifactv1.Descriptor, error)
+}
+
+type artifactService struct {
+	repository     distribution.Repository
+	blobStore      distribution.BlobStore
+	referrersStore referrersStoreFunc
+}
+
+func (as *artifactService) Referrers(ctx context.Context, revision digest.Digest, referrerType string) ([]artifactv1.Descriptor, error) {
+	dcontext.GetLogger(ctx).Debug("(*manifestStore).Referrers")
+
+	var referrers []artifactv1.Descriptor
+
+	manifests, err := as.repository.Manifests(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := as.referrersStore(ctx, revision, referrerType)
+	if err != nil {
+		return nil, err
+	}
+	err = store.Enumerate(ctx, func(referrerRevision digest.Digest) error {
+		man, err := manifests.Get(ctx, referrerRevision)
+		if err != nil {
+			return err
+		}
+
+		ArtifactMan, ok := man.(*artifact.DeserializedManifest)
+		if !ok {
+			// The PUT handler would guard against this situation. Skip this manifest.
+			return nil
+		}
+
+		desc, err := as.blobStore.Stat(ctx, referrerRevision)
+		if err != nil {
+			return err
+		}
+		desc.MediaType, _, _ = man.Payload()
+		referrers = append(referrers, artifactv1.Descriptor{
+			MediaType:    desc.MediaType,
+			Size:         desc.Size,
+			Digest:       desc.Digest,
+			ArtifactType: ArtifactMan.ArtifactType(),
+		})
+		return nil
+	})
+
+	if err != nil {
+		switch err.(type) {
+		case driver.PathNotFoundError:
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return referrers, nil
+}

--- a/vendor/github.com/oras-project/artifacts-spec/LICENSE
+++ b/vendor/github.com/oras-project/artifacts-spec/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 ORAS Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/descriptor.go
+++ b/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/descriptor.go
@@ -1,0 +1,40 @@
+// Copyright 2021 ORAS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import digest "github.com/opencontainers/go-digest"
+
+// Descriptor describes the disposition of targeted content.
+type Descriptor struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType,omitempty"`
+
+	// ArtifactType is the artifact type of the object this schema refers to.
+	//
+	// When the descriptor is used for blobs, this property must be empty.
+	ArtifactType string `json:"artifactType,omitempty"`
+
+	// Digest is the digest of the targeted content.
+	Digest digest.Digest `json:"digest"`
+
+	// Size specifies the size in bytes of the blob.
+	Size int64 `json:"size"`
+
+	// URLs specifies a list of URLs from which this object MAY be downloaded
+	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/manifest.go
@@ -1,0 +1,32 @@
+// Copyright 2021 ORAS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+// Manifest describes an ORAS artifact.
+// This structure provides `application/vnd.oras.artifact.manifest.v1+json` mediatype when marshalled to JSON.
+type Manifest struct {
+	// ArtifactType is the artifact type of the object this schema refers to.
+	ArtifactType string `json:"artifactType"`
+
+	// Blobs is a collection of blobs referenced by this manifest.
+	Blobs []Descriptor `json:"blobs"`
+
+	// Subject is an optional reference to any existing manifest within the repository.
+	// When specified, the artifact is said to be dependent upon the referenced subject.
+	Subject Descriptor `json:"subject"`
+
+	// Annotations contains arbitrary metadata for the artifact manifest.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/mediatype.go
@@ -1,0 +1,20 @@
+// Copyright 2021 ORAS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+const (
+	// MediaTypeArtifactManifest specifies the media type for an ORAS artifact reference type manifest.
+	MediaTypeArtifactManifest = "application/vnd.cncf.oras.artifact.manifest.v1+json"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,6 +149,9 @@ github.com/opencontainers/go-digest
 ## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
+# github.com/oras-project/artifacts-spec v0.0.0-20211011233138-f1308e4c747c
+## explicit
+github.com/oras-project/artifacts-spec/specs-go/v1
 # github.com/prometheus/client_golang v1.1.0
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal


### PR DESCRIPTION
This PR demostrates how ORAS referrer API can be implemented as an distribution extension.

Referrers API is accessible at: `/v2/<name>/_oras/artifacts/referrers?digest=<manifest_digest>`.