### PR TITLE
POC for supporting extended namespaces

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -255,6 +255,8 @@ type Configuration struct {
 		// Repository configures repository-level extensions.
 		Repository map[string][]Extension `yaml:"repository,omitempty"`
 	} `yaml:"extension,omitempty"`
+
+	Extensions map[string]ExtensionConfig `yaml:"extensions,omitempty"`
 }
 
 // LogHook is composed of hook Level and Type.
@@ -644,6 +646,8 @@ type Middleware struct {
 
 // Extension configures named extensions to be applied at desired components.
 type Extension = Middleware
+
+type ExtensionConfig map[string]interface{}
 
 // Proxy configures the registry as a pull through cache
 type Proxy struct {

--- a/registry/extension/extension.go
+++ b/registry/extension/extension.go
@@ -2,6 +2,7 @@ package extension
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/distribution/distribution/v3"
@@ -32,3 +33,39 @@ type Route struct {
 // InitFunc is the type of a server extension factory function and is
 // used to register the constructor for different server extension backends.
 type InitFunc func(ctx context.Context, options map[string]interface{}) ([]Route, error)
+
+// Proposal 2
+type InitExtendedNamespace func(ctx context.Context, options map[string]interface{}, baseNamespace distribution.Namespace) (ExtendedNamespace, error)
+
+type ExtendedNamespace interface {
+	GetRoutes() []Route
+}
+
+var extensions map[string]InitExtendedNamespace
+
+// Register is used to register an InitFunc for
+// a server extension backend with the given name.
+func Register(name string, initFunc InitExtendedNamespace) error {
+	if extensions == nil {
+		extensions = make(map[string]InitExtendedNamespace)
+	}
+
+	if _, exists := extensions[name]; exists {
+		return fmt.Errorf("name already registered: %s", name)
+	}
+
+	extensions[name] = initFunc
+
+	return nil
+}
+
+// Get constructs a server extension with the given options using the named backend.
+func Get(ctx context.Context, name string, options map[string]interface{}, base distribution.Namespace) (ExtendedNamespace, error) {
+	if extensions != nil {
+		if initFunc, exists := extensions[name]; exists {
+			return initFunc(ctx, options, base)
+		}
+	}
+
+	return nil, fmt.Errorf("no server repository extension registered with name: %s", name)
+}

--- a/registry/extension/oras/artifactmanifest.go
+++ b/registry/extension/oras/artifactmanifest.go
@@ -1,0 +1,3 @@
+package oras
+
+// artifact manifest implementing distribution.Manifest

--- a/registry/extension/oras/artifactmanifesthandler.go
+++ b/registry/extension/oras/artifactmanifesthandler.go
@@ -1,0 +1,23 @@
+package oras
+
+import (
+	"context"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/opencontainers/go-digest"
+)
+
+type artifactManifestHandler struct {
+	repository distribution.Repository
+	blobStore  distribution.BlobStore
+}
+
+func (amh *artifactManifestHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
+	// return deserialized manifest
+	return nil, nil
+}
+
+func (ah *artifactManifestHandler) Put(ctx context.Context, man distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {
+	// process the manifest
+	return digest.FromString("manifest from blobstore"), nil
+}

--- a/registry/extension/oras/oras.go
+++ b/registry/extension/oras/oras.go
@@ -1,0 +1,121 @@
+package oras
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/reference"
+	"github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/opencontainers/go-digest"
+)
+
+type orasNamespace struct {
+	distribution.Namespace
+	routes           []extension.Route
+	storageEnabled   bool
+	referrersEnabled bool
+}
+
+type ArtifactRepository interface {
+	distribution.Repository
+	Referrers(ctx context.Context, digest digest.Digest, contnuationToken string) (descs []distribution.Descriptor, nextLink string, err error)
+}
+
+type artifactRepository struct {
+	distribution.Repository
+	storageEnabled   bool
+	referrersEnabled bool
+}
+
+func newOrasNamespace(ctx context.Context, options map[string]interface{}, base distribution.Namespace) (extension.ExtendedNamespace, error) {
+	_, ok := options["artifacts"]
+	if !ok {
+		return nil, nil
+	}
+
+	storageEnabled := false
+	storageComponent, ok := options["artifacts.storageEnabled"]
+	if ok {
+		flag, ok := storageComponent.(bool)
+		if ok {
+			storageEnabled = flag
+		}
+	}
+
+	// config pertaining to component can be simple bool or its own map
+	referrersEnabled := false
+	referrerComponent, ok := options["artifacts.referrersEnabled"]
+	if ok {
+		flag, ok := referrerComponent.(bool)
+		if ok {
+			referrersEnabled = flag
+		}
+	}
+
+	return &orasNamespace{
+		Namespace:        base,
+		referrersEnabled: referrersEnabled,
+		storageEnabled:   storageEnabled,
+	}, nil
+}
+
+func (o *orasNamespace) GetRoutes() []extension.Route {
+	// configure the root and repository level roots
+	var routes []extension.Route
+
+	// based on the component,enable route either at root or repository level
+	if o.referrersEnabled {
+		routes = []extension.Route{
+			{
+				Namespace:  "oras",
+				Extension:  "artifacts",
+				Component:  "referrers",
+				Dispatcher: o.referrersDispatcher,
+			},
+		}
+	}
+
+	return routes
+}
+
+func init() {
+	extension.Register("distribution", newOrasNamespace)
+}
+
+func (o *orasNamespace) referrersDispatcher(ctx *extension.Context, r *http.Request) http.Handler {
+	// parse the request and return the appropriate handler
+	return nil
+}
+
+func (ar *artifactRepository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
+
+	if ar.referrersEnabled || ar.storageEnabled {
+		artifactManifestHandler := artifactManifestHandler{
+			repository: ar,
+			blobStore:  ar.Blobs(ctx),
+			// other parameters required to implement referrers
+		}
+
+		options = append(options, storage.AddManifestHanlder("artifact.v1", &artifactManifestHandler))
+	}
+
+	return ar.Repository.Manifests(ctx, options...)
+}
+
+func (ar *artifactRepository) Referrers(ctx context.Context, digest digest.Digest, contnuationToken string) (descs []distribution.Descriptor, nextLink string, err error) {
+	// query the linked blob store for the referrers using ar.Blobs
+	// if that is not sufficient enrich ar.Blobs with custom blob store
+	return []distribution.Descriptor{}, "", nil
+}
+
+func (o *orasNamespace) Repository(ctx context.Context, name reference.Named) (distribution.Repository, error) {
+	repo, err := o.Repository(ctx, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &artifactRepository{Repository: repo, storageEnabled: o.storageEnabled, referrersEnabled: o.referrersEnabled}, nil
+}


### PR DESCRIPTION
A POC to support the extension model with a config something like this
```yaml
extensions
  oras:
    artifacts:
     KEY:VALUE 
     COMPONETS:       
      - referrers:
             KEY:VALUE
             KEY1:VALUE1         
```

We can see if we need to collapse the component config according to Sajay's feedback
```Presence means it’s active. Only extra options needs to be passed in```

Note: the code adds placeholders without proper implementation but gives an idea of how to author extended namespaces