### PR TITLE
Working prototype for supporting extensions in the distribution

### DIFF
--- a/cmd/registry/config-example.yml
+++ b/cmd/registry/config-example.yml
@@ -11,12 +11,12 @@ http:
   addr: :5000
   headers:
     X-Content-Type-Options: [nosniff]
-auth:
-  htpasswd:
-    realm: basic-realm
-    path: /etc/registry
 health:
   storagedriver:
     enabled: true
     interval: 10s
     threshold: 3
+extensions:
+  orasv2:
+    artifacts:
+      - referrers

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/auth/htpasswd"
 	_ "github.com/distribution/distribution/v3/registry/auth/silly"
 	_ "github.com/distribution/distribution/v3/registry/auth/token"
+	_ "github.com/distribution/distribution/v3/registry/extension/orasv2"
 	_ "github.com/distribution/distribution/v3/registry/extension/repository/distribution"
 	_ "github.com/distribution/distribution/v3/registry/extension/repository/oras"
 	_ "github.com/distribution/distribution/v3/registry/proxy"

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -255,7 +255,11 @@ type Configuration struct {
 		// Repository configures repository-level extensions.
 		Repository map[string][]Extension `yaml:"repository,omitempty"`
 	} `yaml:"extension,omitempty"`
+
+	Extensions map[string]ExtensionConfig `yaml:"extensions,omitempty"`
 }
+
+type ExtensionConfig map[string]interface{}
 
 // LogHook is composed of hook Level and Type.
 // After hooks configuration, it can execute the next handling automatically,

--- a/manifests.go
+++ b/manifests.go
@@ -2,10 +2,16 @@ package distribution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"mime"
 
 	"github.com/opencontainers/go-digest"
+)
+
+var (
+	// ErrManifestFormatNotSupported
+	ErrManifestFormatNotSupported = errors.New("manifest format not supported")
 )
 
 // Manifest represents a registry object specifying a set of

--- a/registry/extension/extensionv2.go
+++ b/registry/extension/extensionv2.go
@@ -1,0 +1,59 @@
+package extension
+
+import (
+	c "context"
+	"fmt"
+	"net/http"
+
+	"github.com/distribution/distribution/v3"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/distribution/distribution/v3/registry/storage"
+)
+
+type RouteDispatchFunc func(extContext *Context, r *http.Request) http.Handler
+
+// Route describes an extended route.
+type ExtendedRoute struct {
+	Namespace  string
+	Extension  string
+	Component  string
+	Descriptor v2.RouteDescriptor
+	Dispatcher RouteDispatchFunc
+}
+
+type ExtendedNamespace interface {
+	storage.ExtendedStorage
+	GetRepositoryRoutes(base distribution.Namespace) []ExtendedRoute
+	GetRegistryRoutes(base distribution.Namespace) []ExtendedRoute
+}
+
+type InitExtendedNamespace func(ctx c.Context, options map[string]interface{}) (ExtendedNamespace, error)
+
+var extensions map[string]InitExtendedNamespace
+
+// Register is used to register an InitFunc for
+// a server extension backend with the given name.
+func Register(name string, initFunc InitExtendedNamespace) error {
+	if extensions == nil {
+		extensions = make(map[string]InitExtendedNamespace)
+	}
+
+	if _, exists := extensions[name]; exists {
+		return fmt.Errorf("name already registered: %s", name)
+	}
+
+	extensions[name] = initFunc
+
+	return nil
+}
+
+// Get constructs a server extension with the given options using the named backend.
+func Get(ctx c.Context, name string, options map[string]interface{}) (ExtendedNamespace, error) {
+	if extensions != nil {
+		if initFunc, exists := extensions[name]; exists {
+			return initFunc(ctx, options)
+		}
+	}
+
+	return nil, fmt.Errorf("no server repository extension registered with name: %s", name)
+}

--- a/registry/extension/orasv2/artifactmanifest.go
+++ b/registry/extension/orasv2/artifactmanifest.go
@@ -1,28 +1,30 @@
-package artifact
+package orasv2
 
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/distribution/distribution/v3"
+	"github.com/opencontainers/go-digest"
 	v1 "github.com/oras-project/artifacts-spec/specs-go/v1"
 )
 
 func init() {
-	/*	unmarshalFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
-			d := new(DeserializedManifest)
-			err := d.UnmarshalJSON(b)
-			if err != nil {
-				return nil, distribution.Descriptor{}, err
-			}
-
-			dgst := digest.FromBytes(b)
-			return d, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: v1.MediaTypeArtifactManifest}, err
+	unmarshalFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		d := new(DeserializedManifest)
+		err := d.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
 		}
-			err := distribution.RegisterManifestSchema(v1.MediaTypeArtifactManifest, unmarshalFunc)
-			if err != nil {
-				panic(fmt.Sprintf("Unable to register ORAS artifact manifest: %s", err))
-			}*/
+
+		dgst := digest.FromBytes(b)
+		return d, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: v1.MediaTypeArtifactManifest}, err
+	}
+	err := distribution.RegisterManifestSchema(v1.MediaTypeArtifactManifest, unmarshalFunc)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register ORAS artifact manifest: %s", err))
+	}
 }
 
 // Manifest describes ORAS artifact manifests.

--- a/registry/extension/orasv2/artifactmanifesthandler.go
+++ b/registry/extension/orasv2/artifactmanifesthandler.go
@@ -1,0 +1,155 @@
+package orasv2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/opencontainers/go-digest"
+)
+
+// artifactManifestHandler is a ManifestHandler that covers ORAS Artifacts.
+type artifactManifestHandler struct {
+	repository distribution.Repository
+	blobStore  distribution.BlobStore
+	linkFunc   storage.LinkFunc
+}
+
+func (amh *artifactManifestHandler) CanUnmarshal(content []byte) bool {
+	var v json.RawMessage
+	return json.Unmarshal(content, &v) == nil
+}
+
+func (amh *artifactManifestHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
+	dcontext.GetLogger(ctx).Debug("(*artifactManifestHandler).Unmarshal")
+
+	if !amh.CanUnmarshal(content) {
+		return nil, distribution.ErrManifestFormatNotSupported
+	}
+
+	dm := &DeserializedManifest{}
+	if err := dm.UnmarshalJSON(content); err != nil {
+		return nil, err
+	}
+
+	return dm, nil
+}
+
+func (ah *artifactManifestHandler) CanPut(man distribution.Manifest) bool {
+	_, ok := man.(*DeserializedManifest)
+	return ok
+}
+
+func (ah *artifactManifestHandler) Put(ctx context.Context, man distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {
+	dcontext.GetLogger(ctx).Debug("(*artifactManifestHandler).Put")
+
+	if !ah.CanPut(man) {
+		return "", distribution.ErrManifestFormatNotSupported
+	}
+
+	da, ok := man.(*DeserializedManifest)
+	if !ok {
+		return "", fmt.Errorf("wrong type put to artifactManifestHandler: %T", man)
+	}
+
+	if err := ah.verifyManifest(ctx, *da, skipDependencyVerification); err != nil {
+		return "", err
+	}
+
+	mt, payload, err := da.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	revision, err := ah.blobStore.Put(ctx, mt, payload)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error putting payload into blobstore: %v", err)
+		return "", err
+	}
+
+	err = ah.indexReferrers(ctx, *da, revision.Digest)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error indexing referrers: %v", err)
+		return "", err
+	}
+
+	return revision.Digest, nil
+}
+
+// verifyManifest ensures that the manifest content is valid from the
+// perspective of the registry. As a policy, the registry only tries to
+// store valid content, leaving trust policies of that content up to
+// consumers.
+func (amh *artifactManifestHandler) verifyManifest(ctx context.Context, dm DeserializedManifest, skipDependencyVerification bool) error {
+	var errs distribution.ErrManifestVerification
+
+	if dm.ArtifactType() == "" {
+		errs = append(errs, distribution.ErrManifestVerification{errors.New("artifactType invalid")})
+	}
+
+	if !skipDependencyVerification {
+		bs := amh.repository.Blobs(ctx)
+
+		// All references must exist.
+		for _, blobDesc := range dm.References() {
+			desc, err := bs.Stat(ctx, blobDesc.Digest)
+			if err != nil && err != distribution.ErrBlobUnknown {
+				errs = append(errs, err)
+			}
+			if err != nil || desc.Digest == "" {
+				// On error here, we always append unknown blob errors.
+				errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: blobDesc.Digest})
+			}
+		}
+
+		ms, err := amh.repository.Manifests(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Validate subject manifest.
+		subject := dm.Subject()
+		exists, err := ms.Exists(ctx, subject.Digest)
+		if !exists || err == distribution.ErrBlobUnknown {
+			errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: subject.Digest})
+		} else if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) != 0 {
+		return errs
+	}
+
+	return nil
+}
+
+// indexReferrers indexes the subject of the given revision in its referrers index store.
+func (amh *artifactManifestHandler) indexReferrers(ctx context.Context, dm DeserializedManifest, revision digest.Digest) error {
+	// We can use artifact type in the link path to support filtering by artifact type
+	//  but need to consider the max path length in different os
+	//artifactType := dm.ArtifactType()
+	subjectRevision := dm.Subject().Digest
+
+	rootPath := path.Join(referrersLinkPath(amh.repository.Named().Name()), subjectRevision.Algorithm().String(), subjectRevision.Hex())
+	referenceLinkPath := path.Join(rootPath, revision.Algorithm().String(), revision.Hex(), "link")
+	if err := amh.linkFunc(ctx, referenceLinkPath, revision); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func referrersLinkPath(name string) string {
+	return path.Join("/docker/registry/", "v2", "repositories", name, "_refs", "subjects")
+}
+
+func canonicalArtifactType(artifactType string) string {
+	return strings.ReplaceAll(artifactType, "/", ".")
+}

--- a/registry/extension/orasv2/artifactservice.go
+++ b/registry/extension/orasv2/artifactservice.go
@@ -1,0 +1,79 @@
+package orasv2
+
+import (
+	"context"
+	"path"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/opencontainers/go-digest"
+	artifactv1 "github.com/oras-project/artifacts-spec/specs-go/v1"
+)
+
+type ArtifactService interface {
+	Referrers(ctx context.Context, revision digest.Digest, referrerType string) ([]artifactv1.Descriptor, error)
+}
+
+// referrersHandler handles http operations on manifest referrers.
+type referrersHandler struct {
+	distribution.Namespace
+	extContext         *extension.Context
+	linkBlobEnumerator storage.LinkBlobEnumerate
+
+	// Digest is the target manifest's digest.
+	Digest digest.Digest
+}
+
+func (h *referrersHandler) Referrers(ctx context.Context, revision digest.Digest, referrerType string) ([]artifactv1.Descriptor, error) {
+	dcontext.GetLogger(ctx).Debug("(*manifestStore).Referrers")
+
+	var referrers []artifactv1.Descriptor
+
+	repo := h.extContext.Repository
+	manifests, err := repo.Manifests(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	blobStatter := h.Namespace.BlobStatter()
+
+	rootPath := path.Join(referrersLinkPath(repo.Named().Name()), revision.Algorithm().String(), revision.Hex())
+	err = h.linkBlobEnumerator(ctx, rootPath, func(referrerRevision digest.Digest) error {
+		man, err := manifests.Get(ctx, referrerRevision)
+		if err != nil {
+			return err
+		}
+
+		ArtifactMan, ok := man.(*DeserializedManifest)
+		if !ok {
+			// The PUT handler would guard against this situation. Skip this manifest.
+			return nil
+		}
+
+		desc, err := blobStatter.Stat(ctx, referrerRevision)
+		if err != nil {
+			return err
+		}
+		desc.MediaType, _, _ = man.Payload()
+		referrers = append(referrers, artifactv1.Descriptor{
+			MediaType:    desc.MediaType,
+			Size:         desc.Size,
+			Digest:       desc.Digest,
+			ArtifactType: ArtifactMan.ArtifactType(),
+		})
+		return nil
+	})
+
+	if err != nil {
+		switch err.(type) {
+		case driver.PathNotFoundError:
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return referrers, nil
+}

--- a/registry/extension/orasv2/orasv2.go
+++ b/registry/extension/orasv2/orasv2.go
@@ -1,0 +1,160 @@
+package orasv2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/gorilla/handlers"
+	"github.com/opencontainers/go-digest"
+	orasartifacts "github.com/oras-project/artifacts-spec/specs-go/v1"
+	"gopkg.in/yaml.v2"
+)
+
+const Name = "orasv2"
+
+type orasNamespace struct {
+	referrersEnabled bool
+	distribution.Namespace
+	linkBlobEnumerator storage.LinkBlobEnumerate
+}
+
+type OrasOptions struct {
+	ArtifactsExtComponents []string `yaml:"artifacts,omitempty"`
+}
+
+func newOrasNamespace(ctx context.Context, options map[string]interface{}) (extension.ExtendedNamespace, error) {
+	optionsYaml, err := yaml.Marshal(options)
+	if err != nil {
+		return nil, err
+	}
+
+	var orasOptions OrasOptions
+	err = yaml.Unmarshal(optionsYaml, &orasOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	referrersEnabled := false
+	for _, component := range orasOptions.ArtifactsExtComponents {
+		if component == "referrers" {
+			referrersEnabled = true
+			break
+		}
+	}
+
+	return &orasNamespace{
+		referrersEnabled: referrersEnabled,
+	}, nil
+}
+
+func init() {
+	extension.Register(Name, newOrasNamespace)
+}
+
+func (o *orasNamespace) GetManifestHandlers(repo distribution.Repository, blobStore distribution.BlobStore, linkFunc storage.LinkFunc) []storage.ManifestHandler {
+	if o.referrersEnabled {
+		return []storage.ManifestHandler{
+			&artifactManifestHandler{
+				repository: repo,
+				blobStore:  blobStore,
+				linkFunc:   linkFunc,
+			}}
+	}
+
+	return []storage.ManifestHandler{}
+}
+
+func (o *orasNamespace) UseLinkBlobEnumerator(enumerator storage.LinkBlobEnumerate) {
+	o.linkBlobEnumerator = enumerator
+}
+
+func (o *orasNamespace) GetRepositoryRoutes(base distribution.Namespace) []extension.ExtendedRoute {
+	o.Namespace = base
+	if o.referrersEnabled {
+		return []extension.ExtendedRoute{
+			{
+				Namespace:  Name,
+				Extension:  "artifacts",
+				Component:  "referrers",
+				Dispatcher: o.referrersDispatcher,
+			},
+		}
+	}
+	return []extension.ExtendedRoute{}
+}
+
+func (o *orasNamespace) GetRegistryRoutes(base distribution.Namespace) []extension.ExtendedRoute {
+	return nil
+}
+
+// referrersResponse describes the response body of the referrers API.
+type referrersResponse struct {
+	Referrers []orasartifacts.Descriptor `json:"references"`
+}
+
+func (o *orasNamespace) referrersDispatcher(extCtx *extension.Context, r *http.Request) http.Handler {
+
+	handler := &referrersHandler{
+		Namespace:          o.Namespace,
+		linkBlobEnumerator: o.linkBlobEnumerator,
+		extContext:         extCtx,
+	}
+	q := r.URL.Query()
+	if dgstStr := q.Get("digest"); dgstStr == "" {
+		dcontext.GetLogger(extCtx).Errorf("digest not available")
+	} else if d, err := digest.Parse(dgstStr); err != nil {
+		dcontext.GetLogger(extCtx).Errorf("error parsing digest=%q: %v", dgstStr, err)
+	} else {
+		handler.Digest = d
+	}
+
+	mhandler := handlers.MethodHandler{
+		"GET": http.HandlerFunc(handler.Get),
+	}
+
+	return mhandler
+}
+
+func (h *referrersHandler) Get(w http.ResponseWriter, r *http.Request) {
+	dcontext.GetLogger(h.extContext).Debug("Get")
+
+	// This can be empty
+	artifactType := r.FormValue("artifactType")
+
+	if h.Digest == "" {
+		h.extContext.Errors = append(h.extContext.Errors, v2.ErrorCodeManifestUnknown.WithDetail("digest not specified"))
+		return
+	}
+
+	referrers, err := h.Referrers(h.extContext, h.Digest, artifactType)
+	if err != nil {
+		if _, ok := err.(distribution.ErrManifestUnknownRevision); ok {
+			h.extContext.Errors = append(h.extContext.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
+		} else {
+			h.extContext.Errors = append(h.extContext.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		}
+		return
+	}
+
+	if referrers == nil {
+		referrers = []orasartifacts.Descriptor{}
+	}
+
+	response := referrersResponse{
+		Referrers: referrers,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	if err = enc.Encode(response); err != nil {
+		h.extContext.Errors = append(h.extContext.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}

--- a/registry/storage/extension.go
+++ b/registry/storage/extension.go
@@ -10,7 +10,19 @@ import (
 	"github.com/distribution/distribution/v3/registry/storage/extension"
 	registryextension "github.com/distribution/distribution/v3/registry/storage/extension/registry"
 	repositoryextension "github.com/distribution/distribution/v3/registry/storage/extension/repository"
+	"github.com/opencontainers/go-digest"
 )
+
+type ExtendedStorage interface {
+	GetManifestHandlers(
+		repo distribution.Repository,
+		blobStore distribution.BlobStore,
+		linkFunc LinkFunc) []ManifestHandler
+	UseLinkBlobEnumerator(linkBlobEnumerator LinkBlobEnumerate)
+}
+
+type LinkBlobEnumerate func(ctx context.Context, rootPath string, ingestor func(digest.Digest) error) error
+type LinkFunc func(ctx context.Context, path string, dgst digest.Digest) error
 
 func ApplyRegistryExtension(ctx context.Context, name string, options map[string]interface{}) RegistryOption {
 	return func(r *registry) error {


### PR DESCRIPTION
This is a working prototype to support extensions to distribution with oras as an example for an extended namespace. I added as orasv2 so that it doesn't conflict with existing extension oras

The config
```yaml
extensions:
  orasv2:
    artifacts:
      - referrers
```

Also, I used a different storage model for persisting referrers
```
v<root>
└── v2
  └── repositories
      └── nginx
          ├── _manifests
          │   └── revisions
          │    └── sha256
          │        ├── 111ma2d22ae5ef400769fa51c84717264cd1520ac8d93dc071374c1be49a111m
          │        │   ├── link
          │        ├── 222ibbf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cb222i
          │        │   └── link
          │        └── 333ic0c33ebc4a74a0a554c86ac2b28ddf3454a5ad9cf90ea8cea9f9e75c333i
          │            └── link
          └── _references			
  	      └── subjects
  		     └── sha256
  	    	         └── 111ma2d22ae5ef400769fa51c84717264cd1520ac8d93dc071374c1be49a111m
  			     ├── digest(application/vnd.example.artifact)
  			     │   └── sha256
  			     │       └── 222ibbf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cb222i
  			     │           └── link <to manifest in _manifests>
  			     └── digest(application/vnd.another.example.artifact)
  				 └── sha256
  				     └── 333ic0c33ebc4a74a0a554c86ac2b28ddf3454a5ad9cf90ea8cea9f9e75c333i
  					└── link <to manifest in _manifests>
```

Couple of benefits are, it aligns with the current model where separate folder exists for entity type like manifests, tags, layers etc. In the similar fashion references will represent index for all referrers. In addition , if we extend references to layers, this model can still be used except for that the link refers to _layers blob and doesn't need any change to the _layers folder. Also, there will be no change to the existing folders and hence existing systems need not be checked for any unexpected behaviors with this new structure under _manifests.